### PR TITLE
Fix how non server URIs are propagated downwards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request-panel",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request-panel",
   "description": "An element to display the response body",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "api-request-panel.js",
   "keywords": [

--- a/src/ApiRequestPanel.js
+++ b/src/ApiRequestPanel.js
@@ -491,7 +491,13 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
   }
 
   get baseUri() {
-      return this._baseUri || this.selectedServerValue;
+      if (this._baseUri) {
+        return this._baseUri;
+      }
+      if (this.selectedServerType !== 'server') {
+        this.selectedServerValue;
+      }
+      return this._baseUri;
   }
 
   set baseUri(value) {

--- a/src/ApiRequestPanel.js
+++ b/src/ApiRequestPanel.js
@@ -490,6 +490,19 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
     this._computeServerSelectorHidden();
   }
 
+  get baseUri() {
+      return this._baseUri || this.selectedServerValue;
+  }
+
+  set baseUri(value) {
+    const old = this._baseUri;
+    if (old === value) {
+      return;
+    }
+    this._baseUri = value;
+    this.requestUpdate('baseUri', old);
+  }
+
   /**
    * @constructor
    */

--- a/src/ApiRequestPanel.js
+++ b/src/ApiRequestPanel.js
@@ -495,7 +495,7 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
         return this._baseUri;
       }
       if (this.selectedServerType !== 'server') {
-        this.selectedServerValue;
+        return this.selectedServerValue;
       }
       return this._baseUri;
   }

--- a/src/ApiRequestPanel.js
+++ b/src/ApiRequestPanel.js
@@ -107,7 +107,7 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
       selected,
       amf,
       noUrlEditor,
-      baseUri,
+      effectiveBaseUri,
       noDocs,
       eventsTarget,
       allowHideOptional,
@@ -134,7 +134,7 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
       .selected="${selected}"
       .amf="${amf}"
       ?noUrlEditor="${noUrlEditor}"
-      .baseUri="${baseUri}"
+      .baseUri="${effectiveBaseUri}"
       ?noDocs="${noDocs}"
       .eventsTarget="${eventsTarget}"
       ?allowHideOptional="${allowHideOptional}"
@@ -490,23 +490,19 @@ export class ApiRequestPanel extends AmfHelperMixin(EventsTargetMixin(HeadersPar
     this._computeServerSelectorHidden();
   }
 
-  get baseUri() {
-      if (this._baseUri) {
-        return this._baseUri;
-      }
-      if (this.selectedServerType !== 'server') {
-        return this.selectedServerValue;
-      }
-      return this._baseUri;
-  }
-
-  set baseUri(value) {
-    const old = this._baseUri;
-    if (old === value) {
-      return;
+  /**
+   * This is the final computed value for the baseUri to propagate downwards
+   * If baseUri is defined, return baseUri
+   * Else, return the selectedServerValue if selectedServerType is not `server`
+   */
+  get effectiveBaseUri() {
+    if (this.baseUri) {
+      return this.baseUri;
     }
-    this._baseUri = value;
-    this.requestUpdate('baseUri', old);
+    if (this.selectedServerType !== 'server') {
+      return this.selectedServerValue;
+    }
+    return '';
   }
 
   /**

--- a/test/api-request-panel.test.js
+++ b/test/api-request-panel.test.js
@@ -130,13 +130,15 @@ describe('<api-request-panel>', function () {
           assert.exists(element.shadowRoot.querySelector('api-server-selector'));
         });
 
-        it('should not change the baseUri property if it is defined', () => {
+        it('effectiveBaseUri should be equal to baseUri', () => {
           element.baseUri = 'https://example.org';
-          assert.equal(element.baseUri, 'https://example.org');
+          assert.equal(element.effectiveBaseUri, element.baseUri);
+          assert.equal(element.effectiveBaseUri, 'https://example.org');
         });
 
-        it('should change baseUri property if it was not defined', () => {
-          assert.equal(element.baseUri, 'https://www.google.com');
+        it('effectiveBaseUri should be equal to selectedServerValue', () => {
+          assert.equal(element.effectiveBaseUri, element.selectedServerValue);
+          assert.equal(element.effectiveBaseUri, 'https://www.google.com');
         });
 
         it('should update computed server', async () => {

--- a/test/api-request-panel.test.js
+++ b/test/api-request-panel.test.js
@@ -90,7 +90,7 @@ describe('<api-request-panel>', function () {
     it('should set hidden attribute to server selector', async () => {
       const element = await basicFixture();
       await nextFrame()
-      let serverSelector = element.shadowRoot.querySelector('api-server-selector')
+      const serverSelector = element.shadowRoot.querySelector('api-server-selector')
       assert.exists(serverSelector);
       assert.isTrue(serverSelector.hidden)
     });
@@ -130,8 +130,13 @@ describe('<api-request-panel>', function () {
           assert.exists(element.shadowRoot.querySelector('api-server-selector'));
         });
 
-        it('should not change the baseUri property', () => {
-          assert.isUndefined(element.baseUri);
+        it('should not change the baseUri property if it is defined', () => {
+          element.baseUri = 'https://example.org';
+          assert.equal(element.baseUri, 'https://example.org');
+        });
+
+        it('should change baseUri property if it was not defined', () => {
+          assert.equal(element.baseUri, 'https://www.google.com');
         });
 
         it('should update computed server', async () => {
@@ -453,7 +458,7 @@ describe('<api-request-panel>', function () {
       })
 
       it('should not set hidden attribute to server selector', async () => {
-        let serverSelector = element.shadowRoot.querySelector('api-server-selector')
+        const serverSelector = element.shadowRoot.querySelector('api-server-selector')
         assert.exists(serverSelector);
         assert.isUndefined(serverSelector.hidden)
       });
@@ -473,7 +478,7 @@ describe('<api-request-panel>', function () {
       })
 
       it('should set hidden attribute to server selector', async () => {
-        let serverSelector = element.shadowRoot.querySelector('api-server-selector')
+        const serverSelector = element.shadowRoot.querySelector('api-server-selector')
         assert.exists(serverSelector);
         assert.isTrue(serverSelector.hidden)
       });
@@ -493,7 +498,7 @@ describe('<api-request-panel>', function () {
         element.noServerSelector = true
         await nextFrame()
         assert.isTrue(element.serverSelectorHidden)
-        let serverSelector = element.shadowRoot.querySelector('api-server-selector')
+        const serverSelector = element.shadowRoot.querySelector('api-server-selector')
         assert.exists(serverSelector);
         assert.isTrue(serverSelector.hidden)
       })


### PR DESCRIPTION
ApiRequestPanel listens for `api-server-changed` event. However, when the server value it received was not a server, it didn't propagate the value downwards.

Now, `this.baseUri` is a getter that attempts to retrieve `this._baseUri` first, then goes for the selectedServerValue only if the selected server type is not `server`. This is because the bottom components should receive the `server` node if possible, in order to compute any necessary information from node. For `custom` and `slot`, we can just treat it as a baseUri.