### PR TITLE
Allow component to render without WebAPI type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-request-panel",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request-panel",
   "description": "An element that renders request editor and response view based on AMF model.",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiRequestPanel.js
+++ b/src/ApiRequestPanel.js
@@ -270,6 +270,11 @@ export class ApiRequestPanel extends AmfHelperMixin(
        * If true, the server selector custom base URI option is rendered
        */
       allowCustomBaseUri: { type: Boolean },
+      /**
+       * If true, will render the component even if the model does not contain
+       * WebAPI type
+       */
+      forceRender: { type: Boolean },
     };
   }
 
@@ -528,7 +533,7 @@ export class ApiRequestPanel extends AmfHelperMixin(
   }
 
   render() {
-    if (this._isNonWebApi()) {
+    if (this._isNonWebApi() && !this.forceRender) {
       return html``;
     }
     return html`<style>

--- a/test/api-request-panel.test.js
+++ b/test/api-request-panel.test.js
@@ -41,6 +41,10 @@ describe('<api-request-panel>', function () {
     );
   }
 
+  async function forceRenderFixture() {
+    return fixture(`<api-request-panel forcerender></api-request-panel>`);
+  }
+
   function appendRequestData(element, request) {
     // eslint-disable-next-line no-param-reassign
     request = request || {};
@@ -399,6 +403,16 @@ describe('<api-request-panel>', function () {
         element.amf = asyncAmf;
         await nextFrame();
         assert.equal(element.shadowRoot.innerHTML, '<!----><!---->');
+        assert.notExists(
+          element.shadowRoot.querySelector('api-request-editor')
+        );
+      });
+
+      it('should render if forceRender is set', async () => {
+        element = await forceRenderFixture();
+        element.amf = asyncAmf;
+        await nextFrame();
+        assert.exists(element.shadowRoot.querySelector('api-request-editor'));
       });
     });
   });


### PR DESCRIPTION
- Add `forceRender` property. This will render the api-request-panel content even if the model does not contain WebAPI type